### PR TITLE
Fix fatal error

### DIFF
--- a/admin/class.converter.base.php
+++ b/admin/class.converter.base.php
@@ -89,7 +89,7 @@ if( !class_exists( 'Convert2Redux' ) ) {
 				$_REQUEST['sections'] =  $this->converter->objectToHTML( $_REQUEST['sections'] );
 
 				global $wp_filesystem;
-				$_REQUEST['migrate_data_class'] = str_replace('<?php', '', $wp_filesystem->get_contents(dirname(__FILE__).'/class.converter.'.$this->framework.'.data.php') );
+				$_REQUEST['migrate_data_class'] = str_replace('<?php', '', file_get_contents(dirname(__FILE__).'/class.converter.'.$this->framework.'.data.php') );
 
 				echo $this->converter->getConfigFile($_REQUEST);
 


### PR DESCRIPTION
Fix "Fatal error:  Call to a member function get_contents() on a non-object (...)" error. As seen in https://github.com/ReduxFramework/redux-converter/issues/4
